### PR TITLE
Use service name as base URL

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -10,7 +10,7 @@ services:
     overrides:
       services:
         environment:
-          BEHAT_PARAMS: '{"extensions" : {"Behat\\MinkExtension" : {"base_url" : "http://lando-pantheon-workflow.lndo.site/"}, "Drupal\\DrupalExtension" : {"drush" :   {  "root":  "/app/web" }}}}'
+          BEHAT_PARAMS: '{"extensions" : {"Behat\\MinkExtension" : {"base_url" : "http://nginx/"}, "Drupal\\DrupalExtension" : {"drush" :   {  "root":  "/app/web" }}}}'
 tooling:
   behat:
     service: appserver


### PR DESCRIPTION
The service name is more reliable for the appserver to access over Docker's private network.